### PR TITLE
Beginning support for a custom render target!

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,5 @@
 		<br>
 
 		<img src="https://camo.githubusercontent.com/614690d5048e75519bbd924ff6ee7f553006d5ba/68747470733a2f2f692e696d6775722e636f6d2f563461355552732e676966" width="460" height="240">
-
-		<script src="examples/gridTest.js"></script>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,4 +21,6 @@
 
 		<img src="https://camo.githubusercontent.com/614690d5048e75519bbd924ff6ee7f553006d5ba/68747470733a2f2f692e696d6775722e636f6d2f563461355552732e676966" width="460" height="240">
 	</body>
+
+	<script src="testing.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 		<script src="library/three/OBJLoader.js"></script>
 		<script src="library/stats/stats.js"></script>
 		<script src="library/log/log.js"></script>
+		<script src="https://gist.githubusercontent.com/nabetaka7/ca62697ad697d9dea8289a5014a6cd8a/raw/27245b317920b9fa1d1f44cd1f47a5da99c6c0c8/EffectComposer.js"></script>
 		<script src="scorpion.js"></script>
 	</head>
 

--- a/scorpion.js
+++ b/scorpion.js
@@ -1,8 +1,7 @@
 // Scorpion library engine built on three.js
 // rewritten 10/4/19
 
-log('_scorpion_ v0.2b -- *made by smallkitten development*');
-log('rewritten from scratch on _10/4/19_');
+log('_scorpion_ v0.3b -- *made by smallkitten development*');
 
 var stats = new Stats(); // stats.js by mrdoob
 stats.showPanel(0);
@@ -31,12 +30,15 @@ function spnDebug(bool) {
 var globalObject = 'global'; // for piggy backing dynamic global variables using this[] =
 var scorpionSelectedObject; // for pointer raycast, click an object to fill this
 
+var globalRenderTarget = 'gblRT'; // for globally storing information from the custom render target
+
 var windowWidth = window.innerWidth;
 var windowHeight = window.innerHeight;
 
 var textureLoader = new THREE.TextureLoader(); // set this here so the code in the material creator is easier to read
 
 var isDynamic = false; // is the renderer dynamic?
+var spnCustomRenderTarget = false; // is there a custom render target to render to?
 
 window.addEventListener('resize', resizeRenderer, false); // resize renderer if the screen size changes
 
@@ -105,7 +107,12 @@ function animate() {
 	stats.begin(); // call the fps monitor here
 
 	requestAnimationFrame(animate);
-	spnRenderer.render(spnScene, spnCamera);
+
+	if (spnCustomRenderTarget = true) { // if theres a custom render target, render to it!
+		spnRenderer.render(spnScene, spnCamera, gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
+	} else {
+		spnRenderer.render(spnScene, spnCamera);
+	}
 
 	stats.end(); // end stats call here
 }
@@ -464,3 +471,19 @@ function spnObjectLoader(path, material, object, x, y, z, xRotate, yRotate, zRot
 }
 
 // ^ this should load textures from a material and apply them to an imported mesh
+// ---------------------------------------------------------
+// EXPERIMENTAL AND DEVELOPER FEATURES:
+
+// SECONDARY RENDER TARGET:
+
+function spnCreateRenderTarget(targetName) { // name -- "SecondaryTarget" -- to be rendered into
+	// create a seperate render target for pulling per-pixel data and depth info.
+
+	spnCustomRenderTarget = true;
+	this[globalRenderTarget + targetName] = new THREE.WebGLRenderTarget(spnRenderer.width, spnRenderer.height);
+
+	// ^^ should create a custom render target that gets rendered to ("SecondaryTarget")
+	// ADD A BUFFER FOR GRABBING PER PIXEL INFO
+
+	log('a new _render target_ has been created');
+}

--- a/scorpion.js
+++ b/scorpion.js
@@ -40,6 +40,8 @@ var textureLoader = new THREE.TextureLoader(); // set this here so the code in t
 var isDynamic = false; // is the renderer dynamic?
 var spnCustomRenderTarget = false; // is there a custom render target to render to?
 
+var spnRay = 'ray'; // holds ray info
+
 window.addEventListener('resize', resizeRenderer, false); // resize renderer if the screen size changes
 
 function resizeRenderer() {
@@ -112,7 +114,7 @@ function animate() {
 		spnRenderer.render(spnScene, spnCamera);
 	} else {
 		spnRenderer.render(spnScene, spnCamera); 
-		spnRenderer.setRenderTarget(gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
+		// spnRenderer.setRenderTarget(gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
 	}
 
 	stats.end(); // end stats call here
@@ -487,4 +489,14 @@ function spnCreateRenderTarget(targetName) { // name -- "SecondaryTarget" -- to 
 	// ADD A BUFFER FOR GRABBING PER PIXEL INFO
 
 	log('a new _render target_ has been created');
+}
+
+// RAY CASTING
+// using this along with the info from the render target should give plenty of info
+
+function spnScreenspaceRaycasting() {
+	log('_RAYCASTER ENABLED_');
+
+	var spnRendererSize = spnRenderer.getSize(); // calculate rays being cast
+	log(spnRendererSize.x * spnRendererSize.y + ' rays being cast');
 }

--- a/scorpion.js
+++ b/scorpion.js
@@ -108,10 +108,11 @@ function animate() {
 
 	requestAnimationFrame(animate);
 
-	if (spnCustomRenderTarget = true) { // if theres a custom render target, render to it!
-		spnRenderer.render(spnScene, spnCamera, gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
-	} else {
+	if (spnCustomRenderTarget = false) { // check for custom target
 		spnRenderer.render(spnScene, spnCamera);
+	} else {
+		spnRenderer.render(spnScene, spnCamera); 
+		spnRenderer.setRenderTarget(gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
 	}
 
 	stats.end(); // end stats call here

--- a/scorpion.js
+++ b/scorpion.js
@@ -115,11 +115,12 @@ function animate() {
 
 	requestAnimationFrame(animate);
 
-	if (spnCustomRenderTarget = false) { // check for custom target
-		spnRenderer.render(spnScene, spnCamera);
+	spnRenderer.render(spnScene, spnCamera);
+
+	if (spnCustomRenderTarget == true) {
+		spnRenderer.setRenderTarget(gblRTSecondaryTarget);
 	} else {
-		spnRenderer.render(spnScene, spnCamera); 
-		// spnRenderer.setRenderTarget(gblRTSecondaryTarget); // renders objects and passes renderer info to custom render target "SecondaryTarget"
+		// do nothing
 	}
 
 	stats.end(); // end stats call here
@@ -487,13 +488,15 @@ function spnObjectLoader(path, material, object, x, y, z, xRotate, yRotate, zRot
 function spnCreateRenderTarget(targetName) { // name -- "SecondaryTarget" -- to be rendered into
 	// create a seperate render target for pulling per-pixel data and depth info.
 
-	spnCustomRenderTarget = true;
 	this[globalRenderTarget + targetName] = new THREE.WebGLRenderTarget(spnRenderer.width, spnRenderer.height);
 
 	// ^^ should create a custom render target that gets rendered to ("SecondaryTarget")
 	// ADD A BUFFER FOR GRABBING PER PIXEL INFO
 
+	spnCustomRenderTarget = true;
 	log('a new _render target_ has been created');
 }
 
 // TESTING:
+
+// no testing functions now

--- a/scorpion.js
+++ b/scorpion.js
@@ -499,4 +499,9 @@ function spnScreenspaceRaycasting() {
 
 	var spnRendererSize = spnRenderer.getSize(); // calculate rays being cast
 	log(spnRendererSize.x * spnRendererSize.y + ' rays being cast');
+
+	this[globalObject + "ScreenspaceVector"] = new THREE.Vector2();
+	this[globalObject + "ScreenspaceVector2"] = new THREE.Vector2(0, 5);
+
+	spnCube('basic', white, 1, 1, 1, globalScreenspaceVector.x, globalScreenspaceVector.y, -2, false, 'VectorCube');
 }

--- a/scorpion.js
+++ b/scorpion.js
@@ -40,7 +40,12 @@ var textureLoader = new THREE.TextureLoader(); // set this here so the code in t
 var isDynamic = false; // is the renderer dynamic?
 var spnCustomRenderTarget = false; // is there a custom render target to render to?
 
+// -- DEV PATH TRACING --
+
 var spnRay = 'ray'; // holds ray info
+var spnRaycaster =  new THREE.Raycaster();
+
+// -- -- -- -- -- -- -- -- 
 
 window.addEventListener('resize', resizeRenderer, false); // resize renderer if the screen size changes
 
@@ -491,17 +496,4 @@ function spnCreateRenderTarget(targetName) { // name -- "SecondaryTarget" -- to 
 	log('a new _render target_ has been created');
 }
 
-// RAY CASTING
-// using this along with the info from the render target should give plenty of info
-
-function spnScreenspaceRaycasting() {
-	log('_RAYCASTER ENABLED_');
-
-	var spnRendererSize = spnRenderer.getSize(); // calculate rays being cast
-	log(spnRendererSize.x * spnRendererSize.y + ' rays being cast');
-
-	this[globalObject + "ScreenspaceVector"] = new THREE.Vector2();
-	this[globalObject + "ScreenspaceVector2"] = new THREE.Vector2(0, 5);
-
-	spnCube('basic', white, 1, 1, 1, globalScreenspaceVector.x, globalScreenspaceVector.y, -2, false, 'VectorCube');
-}
+// TESTING:

--- a/scorpion.js
+++ b/scorpion.js
@@ -135,7 +135,8 @@ function spnScene(fov, x, y, z, backgroundColor) {
 
 	// ^ sets up scene (spnScene as of rewrite) with a background color
 
-	spnRenderer = new THREE.WebGLRenderer({antialias: true, shadowMapEnabled: true});
+	spnRenderer = new THREE.WebGLRenderer({antialias: true});
+	spnRenderer.shadowMap.enabled = true;
 
 	// ^ sets up a renderer with antialiasing variable and a shadow map
 
@@ -480,6 +481,27 @@ function spnObjectLoader(path, material, object, x, y, z, xRotate, yRotate, zRot
 }
 
 // ^ this should load textures from a material and apply them to an imported mesh
+
+// ---------------------------------------------------------
+// POST PROCESSING:
+
+function spnPostProcessing(scale, shader, renderTarget, swap) {
+	log('post processing ' + shader + 'pass at ' + scale +  ' resolution');
+	var pass;
+
+	postProcessingRT = new THREE.WebGLRenderTarget(spnRenderer.width * scale, spnRenderer.height * scale);
+	postProcessingComposer = new THREE.EffectComposer(spnRenderer, postProcessingRT);
+
+	postProcessingComposer.addPass(new THREE.RenderPass(spnScene, spnCamera));
+
+	pass = new THREE.ShaderPass(shader);
+	pass.needsSwap = swap;
+
+	postProcessingComposer.addPass(pass);
+
+	pass.renderToScreen = true;
+}
+
 // ---------------------------------------------------------
 // EXPERIMENTAL AND DEVELOPER FEATURES:
 

--- a/testing.js
+++ b/testing.js
@@ -1,4 +1,4 @@
 log('test loaded');
 
 spnScene(90, 0, 0, 0, black);
-spnScreenspaceRaycasting();
+spnCreateRenderTarget('SecondaryTarget');

--- a/testing.js
+++ b/testing.js
@@ -1,4 +1,14 @@
-log('test loaded');
-
 spnScene(90, 0, 0, 0, black);
-spnCreateRenderTarget('SecondaryTarget');
+
+spnCube('phong', white, 2, 2, 2, 0, 0, -5, false, 'CubeOne');
+
+spnLight('ambient', black, 0, 0, 0, 100, false, 'AMBLightOne');
+spnLight('point', white, 0.28, 0, -1, .8, true, 'LightOne');
+
+spnWall('phong', 8, 8, 0, 0, -6, 0, 0, 12, orange, false, 'WallOne');
+spnWall('phong', 8, 8, 4, 0, -6, 0, Math.PI / 2, 12, orange, false, 'WallTwo');
+spnWall('phong', 8, 8, -4, 0, -6, 0, -Math.PI / 2, 12, orange, false, 'WallThree');
+
+// spnFloor(material, width, height, x, y, z, triangles, clr, wirefrm, objectName)
+spnFloor('phong', 8, 8, 0, -4, -2, 12, orange, false, 'FloorOne');
+spnFloor('phong', 8, 8, 0, 4, -2, 12, orange, false, 'CelingOne');

--- a/testing.js
+++ b/testing.js
@@ -1,0 +1,4 @@
+log('test loaded');
+
+spnScene(90, 0, 0, 0, black);
+spnScreenspaceRaycasting();


### PR DESCRIPTION
- Started adding support for a custom render target, for making effects and grabbing info on a per-pixel basis and info from the depth buffer.

- Added support for native render passes within Scorpion for easier use of post processing shaders. Used in conjunction with the secondary render pass function.